### PR TITLE
generate .d.ts file on publish

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -174,3 +174,6 @@ dist
 
 # Finder (MacOS) folder config
 .DS_Store
+
+# Generated types
+types

--- a/lib/index.js
+++ b/lib/index.js
@@ -9,7 +9,7 @@ const FILE_TYPE = {
 /**
  * @typedef FileDescription
  * @property {string} name - The name of the file.
- * @property {"file"|"directory"} type - The type of the file, either "file" or "directory".
+ * @property {"file"|"directory"|number} type - The type of the file, either "file" or "directory".
  * @property {number} size - The size of the file in bytes.
  * @property {Uint8Array} data - The binary data of the file content.
  * @property {string} text - A getter to decode and return the file content as a UTF-8 string.
@@ -32,7 +32,7 @@ const FILE_TYPE = {
  * @returns {Promise<FileDescription[]>} - An array of FileDescription objects representing the parsed files in the tar archive.
  */
 export async function parseTar(data) {
-	let buffer = data.buffer || data;
+	let buffer = /** @type {Uint8Array} */ (data).buffer || /** @type {ArrayBuffer} */ (data);
 
 	const ftype = checkFileType(buffer);
 	if (ftype != FILE_TYPE.GZIP && ftype != FILE_TYPE.TAR) {
@@ -54,6 +54,7 @@ export async function parseTar(data) {
 		// TODO: we should again check the buffer type to make sure is a tar inside the gzip
 	}
 
+	/** @type {FileDescription[]} */
 	const files = [];
 	let offset = 0;
 

--- a/package.json
+++ b/package.json
@@ -6,7 +6,17 @@
 	"author": "highercomve",
 	"license": "MIT",
 	"description": "TAR parser written in pure javascript",
-	"devDependencies": {},
-	"peerDependencies": {},
+	"devDependencies": {
+		"typescript": "^5.6.3"
+	},
+	"scripts": {
+		"prepublishOnly": "tsc --lib esnext,dom --emitDeclarationOnly --declaration --declarationMap --allowJs --checkJs --outDir types lib/index.js"
+	},
+	"exports": {
+		".": {
+			"types": "./types/index.d.ts",
+			"default": "./lib/index.js"
+		}
+	},
 	"version": "0.0.2"
 }


### PR DESCRIPTION
Hello! Thank you for this library — we're investigating using it on https://svelte.dev/playground.

As you can see on the [PR](https://github.com/sveltejs/svelte.dev/pull/745/files), we needed to add a `declare module` declaration in order to use it with type safety, and the declaration files are quite large (and prone to get out of date). Since you've already gone to the trouble of annotating everything with JSDoc comments, I wondered if you'd be open to a small `prepublishOnly` script that generates `.d.ts` files automatically?

It _does_ introduce a devDependency on `typescript`, which I recognise isn't everyone's cup of tea. But it allows users of this library to get autocomplete and inline documentation and type safety, and also helps to ensure that this package remains bug-free (e.g. you'll notice TypeScript caught a small discrepancy in the `type` field).

Thank you for your consideration!
