### PR TITLE
add files array to package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -18,5 +18,11 @@
       "default": "./lib/index.js"
     }
   },
+  "files": [
+    "deno.json",
+    "index.js",
+    "lib",
+    "types"
+  ],
   "version": "0.0.3"
 }

--- a/package.json
+++ b/package.json
@@ -24,5 +24,5 @@
     "lib",
     "types"
   ],
-  "version": "0.0.3"
+  "version": "0.0.4"
 }

--- a/package.json
+++ b/package.json
@@ -19,8 +19,6 @@
     }
   },
   "files": [
-    "deno.json",
-    "index.js",
     "lib",
     "types"
   ],


### PR DESCRIPTION
per https://github.com/highercomve/tarparser/pull/1#issuecomment-2454746510, I messed up in #1 by not adding a `"files"` field to `package.json`. Without it, the `types` directory that gets generated in `prepublishOnly` is excluded from the package, because it's listed in `.gitignore`.

With this PR, the following files are included (found by running `npm pack --dry-run`):

```
README.md
deno.json
index.js
lib/index.js
package.json
types/index.d.ts
types/index.d.ts.map
```

Note that this _doesn't_ include the image files, which were previously included  — if it's important to include these in that package then adding `"*.svg", "*.webp", "*.png"` to the array will work.

Apologies for the inconvenience!