### PR TITLE
Parse UID and GID as octal, as documented, instead of as decimal

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -81,11 +81,11 @@ export async function parseTar(data) {
 
 		// File uid (8 bytes, octal number stored as ASCII)
 		// User ID of the file owner
-		const uid = Number.parseInt(readString(buffer, offset + 108, 8));
+		const uid = readNumber(buffer, offset + 108, 8);
 
 		// File gid (8 bytes, octal number stored as ASCII)
 		// Group ID of the file owner
-		const gid = Number.parseInt(readString(buffer, offset + 116, 8));
+		const gid = readNumber(buffer, offset + 116, 8);
 
 		// File size (12 bytes, octal number stored as ASCII)
 		// Size of the file in bytes


### PR DESCRIPTION
When reading an archive with files owned by 1000:100, this would say it's actually 1750:144.